### PR TITLE
Fix broken CSS block preventing styles from loading

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -13,30 +13,6 @@ html {
   left: 0;
 }
 
-.section {
-  padding: 4rem 0;
-}
-
-.section-inner {
-  max-width: 72rem;
-  margin: 0 auto;
-  padding: 0 1rem;
-
-  /* Design system additions complementing Tailwind */
-  /* Utilities & custom components */
-  html {
-    scroll-padding-top: 72px;
-  }
-
-  .skip-link {
-    position: absolute;
-    left: -999px;
-  }
-
-  .skip-link:focus {
-    left: 0;
-  }
-
   .section {
     padding: 4rem 0;
   }


### PR DESCRIPTION
## Summary
- remove accidental nested duplicate CSS declarations
- balance opening brace so the stylesheet parses and applies properly

## Testing
- not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939cfebfe6083338faaf023274b92b2)